### PR TITLE
use README as long_description in setup sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 import setuptools
 
+with open('README.md') as f:
+    long_description = f.read()
+
 setuptools.setup(
     name="pywarmup",
     version="0.1.0",
     description="Client library for Warmup thermostats",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     license="Apache",
     author="Laszlo Kiss Kollar",
     author_email="kiss.kollar.laszlo@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import setuptools
 
-with open('README.md') as f:
+with open("README.md") as f:
     long_description = f.read()
 
 setuptools.setup(
@@ -9,7 +9,7 @@ setuptools.setup(
     version="0.1.0",
     description="Client library for Warmup thermostats",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     license="Apache",
     author="Laszlo Kiss Kollar",
     author_email="kiss.kollar.laszlo@gmail.com",


### PR DESCRIPTION
work around `The author of this package has not provided a project description` in https://pypi.org/project/pywarmup/ by using the contents of README.md to automatically generate the long_description as per https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/